### PR TITLE
Added monitor_activity_files to check_output for to reset inactivity_…

### DIFF
--- a/firexapp/firex_subprocess.py
+++ b/firexapp/firex_subprocess.py
@@ -511,12 +511,11 @@ def _subprocess_runner(cmd: Union[str, list], runner_type: _SubprocessRunnerType
 
                 # Inactivity timeout check
                 current_output_size = os.fstat(f.fileno()).st_size
-                for file in found_monitor_activity_files:
+                for monitor_activity_file in found_monitor_activity_files:
                     try:
-                        with open(file, 'r') as fp:
-                            current_output_size += os.fstat(fp.fileno()).st_size
-                    except Exception as e:
-                        logger.error(f"An error occurred while opening and reading {file} size: {e}")
+                        current_output_size += os.stat(monitor_activity_file).st_size
+                    except OSError as e:
+                        logger.error(f"An error occurred while getting the size of {monitor_activity_file}: {e}")
 
                 if last_output_size != current_output_size:
                     # We have some activity!

--- a/firexapp/firex_subprocess.py
+++ b/firexapp/firex_subprocess.py
@@ -511,11 +511,14 @@ def _subprocess_runner(cmd: Union[str, list], runner_type: _SubprocessRunnerType
 
                 # Inactivity timeout check
                 current_output_size = os.fstat(f.fileno()).st_size
+                already_logged_errors = set()
                 for monitor_activity_file in found_monitor_activity_files:
                     try:
                         current_output_size += os.stat(monitor_activity_file).st_size
                     except OSError as e:
-                        logger.error(f"An error occurred while getting the size of {monitor_activity_file}: {e}")
+                        if monitor_activity_file not in already_logged_errors:
+                            logger.error(f"An error occurred while getting the size of {monitor_activity_file}: {e}")
+                            already_logged_errors.add(monitor_activity_file)
 
                 if last_output_size != current_output_size:
                     # We have some activity!


### PR DESCRIPTION
Can monitor file (list of files/globs) for inactivity 

check_output(cmd, inactivity_timeout=1, monitor_activity_files="/filepath")
check_output(cmd, inactivity_timeout=1, monitor_activity_files=["filename", "dir/*"])