### PR TITLE
Use run-level marker to determine whether a FireX run is revoked

### DIFF
--- a/firexapp/engine/run_controller.py
+++ b/firexapp/engine/run_controller.py
@@ -3,6 +3,7 @@ import logging
 
 from celery.app.base import Celery
 from firexapp.reporters.json_reporter import RevokeDetails, FireXRunData
+from firexapp.run_revocation import backend_get_root_revoked, backend_set_root_revoked
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class FireXRunController:
 
         # revoke can be fast, so do data tracking setup before control.revoke()
         if is_root_task:
-            _backend_set_root_revoked(self.celery_app)
+            backend_set_root_revoked(self.celery_app)
 
         RevokeDetails(
             self.logs_dir,
@@ -58,12 +59,12 @@ class FireXRunController:
 
     def is_run_revoke_started(self) -> bool:
         return (
-            (self.celery_app and _backend_get_root_revoked(self.celery_app))
+            (self.celery_app and backend_get_root_revoked(self.celery_app))
             or self.run_revoke_complete()
         )
 
     def get_current_run_revoke(self) -> Optional[RevokeDetails]:
-        if self.celery_app and _backend_get_root_revoked(self.celery_app):
+        if self.celery_app and backend_get_root_revoked(self.celery_app):
             return None
         return RevokeDetails.load_latest_run_revoke_details(
             self.logs_dir,
@@ -73,17 +74,3 @@ class FireXRunController:
         return FireXRunData.load_from_logs_dir(
             self.logs_dir,
         ).revoked
-
-_RUN_REVOKE_STARTED_KEY = 'ROOT_REVOKED'
-
-#
-# Set flag in backend DB (i.e.: Redis) to indicate root taks has been revoked
-#
-def _backend_set_root_revoked(celery_app: Celery):
-    celery_app.backend.set(_RUN_REVOKE_STARTED_KEY, 'True')
-
-#
-# Get flag in backend DB (i.e.: Redis) which indicates root taks has been revoked
-#
-def _backend_get_root_revoked(celery_app: Celery):
-    return celery_app.backend.get(_RUN_REVOKE_STARTED_KEY)

--- a/firexapp/run_revocation.py
+++ b/firexapp/run_revocation.py
@@ -1,0 +1,27 @@
+"""Helpers for storing and reading run-level revocation state."""
+
+from typing import Any, Optional
+
+from celery.app.base import Celery
+from celery.states import RETRY, REVOKED
+
+ROOT_REVOKED_BACKEND_KEY = 'ROOT_REVOKED'
+
+
+def backend_set_root_revoked(celery_app: Celery) -> None:
+    """Persist that the run has been revoked."""
+    celery_app.backend.set(ROOT_REVOKED_BACKEND_KEY, 'True')
+
+
+def backend_get_root_revoked(celery_app: Celery) -> Optional[Any]:
+    """Return the persisted run revocation marker."""
+    return celery_app.backend.get(ROOT_REVOKED_BACKEND_KEY)
+
+
+def is_root_revoked(celery_app: Celery, result_state: Optional[str] = None) -> bool:
+    """Return whether the run should be treated as revoked."""
+    if result_state in [REVOKED, RETRY]:
+        return True
+
+    revoked = backend_get_root_revoked(celery_app)
+    return revoked is not None and revoked.decode().lower() == 'true'

--- a/firexapp/submit/submit.py
+++ b/firexapp/submit/submit.py
@@ -39,6 +39,7 @@ from firexapp.submit.install_configs import load_new_install_configs, FireXInsta
 from firexapp.submit.arguments import whitelist_arguments
 from firexapp.common import dict2str, silent_mkdir, create_link
 from firexapp.reporters.json_reporter import FireXJsonReportGenerator, FireXRunData
+from firexapp.run_revocation import is_root_revoked
 
 add_hostname_to_log_records()
 logger = setup_console_logging(__name__)
@@ -90,6 +91,7 @@ class AdjustCeleryConcurrency(argparse.Action):
 
 def _safe_create_completed_run_json(uid, chain_result, run_revoked, chain_args, shutdown_reason):
     if uid:
+        run_revoked = run_revoked or is_root_revoked(app)
         chain_args = dict(chain_args or {})
         for k in ['uid', 'root_id', 'run_revoked', 'shutdown_reason']:
             chain_args.pop(k, None) # gotta love **chain_args

--- a/firexapp/tasks/root_tasks.py
+++ b/firexapp/tasks/root_tasks.py
@@ -53,10 +53,10 @@ def handle_firex_root_completion(sender, task, task_id, args, kwargs, **do_not_c
     sync = kwargs.get("sync", False)
 
     result_state = result.state
-    is_revoked = is_root_revoked(app, result_state)
+    is_revoked = is_root_revoked(task.app, result_state)
 
     if is_revoked:
-        backend_set_root_revoked(app)
+        backend_set_root_revoked(task.app)
 
     if sync and not is_revoked:
         logger.debug("Sync run has not been revoked. Cleanup skipped.")

--- a/firexapp/tasks/root_tasks.py
+++ b/firexapp/tasks/root_tasks.py
@@ -3,13 +3,13 @@ import os
 from importlib import import_module
 from celery import bootsteps
 from celery.signals import task_postrun
-from celery.states import REVOKED, RETRY
 from celery.utils.log import get_task_logger
 from firexkit.chain import InjectArgs
 from firexkit.result import find_unsuccessful_in_chain, get_results, RUN_RESULTS_NAME, RUN_UNSUCCESSFUL_NAME
 
 from firexapp.application import get_app_tasks
 from firexapp.engine.celery import app
+from firexapp.run_revocation import backend_set_root_revoked, is_root_revoked
 
 logger = get_task_logger(__name__)
 
@@ -53,7 +53,10 @@ def handle_firex_root_completion(sender, task, task_id, args, kwargs, **do_not_c
     sync = kwargs.get("sync", False)
 
     result_state = result.state
-    is_revoked = result_state in [REVOKED, RETRY] # Revoked can be in retry state with celery 5.1.0
+    is_revoked = is_root_revoked(app, result_state)
+
+    if is_revoked:
+        backend_set_root_revoked(app)
 
     if sync and not is_revoked:
         logger.debug("Sync run has not been revoked. Cleanup skipped.")


### PR DESCRIPTION
## Summary

Today, FireX records run-level cancellation in the Celery backend by setting a persistent marker, but when the FireX run is finalized, this marker is not consulted.

This means cancelled runs can be misclassified if the run has already been marked revoked in the backend but the root task does not itself finish in a revoked state. In these cases, `revoked` will not be set to `true` in `run.json`.

This change ensures the persistent marker is consulted when the FireX run is finalized.
